### PR TITLE
fix(android): strip ICY metadata on radio livestreams to fix audio ch…

### DIFF
--- a/android/src/main/java/com/audiobrowser/player/TransformingDataSource.kt
+++ b/android/src/main/java/com/audiobrowser/player/TransformingDataSource.kt
@@ -71,6 +71,12 @@ class TransformingDataSource(
     return upstream.read(buffer, offset, length)
   }
 
+  // Delegate to upstream so ExoPlayer can read icy-metaint and strip ICY/Shoutcast
+  // metadata. Without this, the metadata bytes are decoded as audio (chirping).
+  override fun getResponseHeaders(): Map<String, List<String>> {
+    return upstream.responseHeaders
+  }
+
   override fun addTransferListener(transferListener: TransferListener) {
     upstream.addTransferListener(transferListener)
   }


### PR DESCRIPTION
…irping

TransformingDataSource did not override getResponseHeaders(), so it returned an empty map and hid the icy-metaint response header from ExoPlayer. Without that header, ProgressiveMediaPeriod never wrapped the stream in an IcyDataSource, so interleaved Shoutcast/Icecast metadata was decoded as audio — producing a periodic "chirping" artifact on radio livestreams. Delegate getResponseHeaders() to the upstream source so ExoPlayer can detect icy-metaint, strip the metadata, and emit ICY now-playing events.