### PR TITLE
fix(ios): do not automaticaly play completed content

### DIFF
--- a/ios/Player/PlaybackStateMachine.swift
+++ b/ios/Player/PlaybackStateMachine.swift
@@ -25,7 +25,7 @@ func nextPlaybackState(from current: PlaybackState, on event: PlaybackEvent) -> 
     return .paused
 
   case .bufferingSufficient:
-    guard current != .playing else { return nil }
+    guard current != .playing, current != .ended else { return nil }
     return .ready
   }
 }


### PR DESCRIPTION
On iOs, if you seek to near the end of the "Chapters" track in the example app, after playback completes, it changes from a stopped to a playing state. In our app, this behavior upon complete (with nothing else in the queue and when not set to repeat) is causing some bad analytics. This fix prevents the auto playing after completion.