### PR TITLE
test(ios): make the three flaky Swift tests deterministic

### DIFF
--- a/ios/Player/MediaLoader.swift
+++ b/ios/Player/MediaLoader.swift
@@ -25,7 +25,9 @@ final class MediaLoader {
 
   weak var delegate: MediaLoaderDelegate?
 
-  private var mediaResolverTask: Task<Void, Never>?
+  /// The in-flight resolve. Readable so tests can await the resolve-then-load
+  /// chain instead of sleeping past it; only this type starts and cancels it.
+  private(set) var mediaResolverTask: Task<Void, Never>?
   private var metadataLoadTask: Task<Void, Never>?
   private var playableLoadTask: Task<Void, Never>?
   private var url: URL?

--- a/ios/Player/PlaybackCoordinator.swift
+++ b/ios/Player/PlaybackCoordinator.swift
@@ -76,7 +76,10 @@ class PlaybackCoordinator {
   /// the window/attempt counters otherwise reset only on track change.
   /// Overridable in tests.
   var healthyPlaybackDuration: TimeInterval = 20
-  private var healthyPlaybackTask: Task<Void, Never>?
+
+  /// The pending refill. Readable so tests can await the window instead of
+  /// sleeping past it; only this type arms and cancels it.
+  private(set) var healthyPlaybackTask: Task<Void, Never>?
 
   /// Playback rate (1.0 = normal speed).
   var rate: Float = 1.0

--- a/ios/Player/SleepTimerManager.swift
+++ b/ios/Player/SleepTimerManager.swift
@@ -7,15 +7,51 @@ import Foundation
 /// Type alias for the Nitro SleepTimer variant type
 typealias SleepTimerState = SleepTimer
 
+/// A scheduled job that has not run yet. `cancel()` is nonisolated so `deinit`
+/// — always nonisolated in Swift 6 — can tear pending work down.
+protocol SleepTimerJob: AnyObject {
+  func cancel()
+}
+
+extension DispatchWorkItem: SleepTimerJob {}
+
+/// Runs work after a delay. Injected into `SleepTimerManager` so tests can
+/// drive the clock instead of racing it: production schedules on the main
+/// queue, tests hand in a scheduler they advance by hand.
+@MainActor
+protocol SleepTimerScheduling {
+  func schedule(
+    after delay: TimeInterval,
+    _ work: @escaping @Sendable @MainActor () -> Void,
+  ) -> any SleepTimerJob
+}
+
+struct MainQueueSleepTimerScheduler: SleepTimerScheduling {
+  func schedule(
+    after delay: TimeInterval,
+    _ work: @escaping @Sendable @MainActor () -> Void,
+  ) -> any SleepTimerJob {
+    let job = DispatchWorkItem { MainActor.assumeIsolated { work() } }
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: job)
+    return job
+  }
+}
+
 /// Manages sleep timer functionality for the audio player.
 /// Supports both time-based timers and end-of-track timers.
 @MainActor
 class SleepTimerManager: SleepTimerHandling {
   // MARK: - Properties
 
+  private let scheduler: any SleepTimerScheduling
+
   // nonisolated(unsafe) for deinit cleanup — deinit is always nonisolated in Swift 6.
-  private nonisolated(unsafe) var sleepTimerJob: DispatchWorkItem?
-  private nonisolated(unsafe) var fadeJob: DispatchWorkItem?
+  private nonisolated(unsafe) var sleepTimerJob: (any SleepTimerJob)?
+  private nonisolated(unsafe) var fadeJob: (any SleepTimerJob)?
+
+  init(scheduler: any SleepTimerScheduling = MainQueueSleepTimerScheduler()) {
+    self.scheduler = scheduler
+  }
 
   /// The time when playback should stop (seconds since epoch), or -1 if inactive
   private(set) var sleepTimerTime: TimeInterval = -1 {
@@ -94,23 +130,15 @@ class SleepTimerManager: SleepTimerHandling {
   func set(seconds: TimeInterval, fadeDuration: TimeInterval? = nil) {
     cancelSleepTimerJob()
     onFadeCancel?()
-    let job = DispatchWorkItem { [weak self] in
-      MainActor.assumeIsolated {
-        self?.complete()
-      }
-    }
-    sleepTimerJob = job
     sleepTimerTime = Date().timeIntervalSince1970 + seconds
-    DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: job)
+    sleepTimerJob = scheduler.schedule(after: seconds) { [weak self] in
+      self?.complete()
+    }
     if let fadeDuration, fadeDuration > 0 {
       let fade = min(fadeDuration, seconds)
-      let fadeJob = DispatchWorkItem { [weak self] in
-        MainActor.assumeIsolated {
-          self?.onFadeStart?(fade)
-        }
+      fadeJob = scheduler.schedule(after: seconds - fade) { [weak self] in
+        self?.onFadeStart?(fade)
       }
-      self.fadeJob = fadeJob
-      DispatchQueue.main.asyncAfter(deadline: .now() + (seconds - fade), execute: fadeJob)
     }
     if let state = get() { onChanged?(state) }
   }

--- a/ios/Tests/MediaLoaderTests.swift
+++ b/ios/Tests/MediaLoaderTests.swift
@@ -123,8 +123,7 @@ struct ResolveAndLoadTests {
     }
     loader.resolveAndLoad(src: "https://example.com/audio.mp3")
 
-    // Allow the resolver task to run
-    await Task.yield()
+    await loader.mediaResolverTask?.value
 
     #expect(resolverCalled == true)
   }
@@ -136,12 +135,9 @@ struct ResolveAndLoadTests {
     }
     loader.resolveAndLoad(src: "https://example.com/audio.mp3")
 
-    // The resolver runs in a Task that awaits the resolver then does MainActor.run,
-    // so we need multiple yields for the full chain to settle.
-    for _ in 0 ..< 10 {
-      await Task.yield()
-      if !spy.playbackErrors.isEmpty { break }
-    }
+    // The task awaits the resolver then hops back to the main actor, so the
+    // delegate call has landed by the time the task itself completes.
+    await loader.mediaResolverTask?.value
 
     #expect(spy.playbackErrors.count == 1)
     if case let .invalidSourceUrl(url) = spy.playbackErrors.first {
@@ -166,8 +162,8 @@ struct ResolveAndLoadTests {
     // Immediately start second — should cancel first
     loader.resolveAndLoad(src: "https://example.com/second.mp3")
 
-    // Wait for both to settle
-    try? await Task.sleep(for: .milliseconds(200))
+    // Await the surviving task; the cancelled one bailed before its resolver.
+    await loader.mediaResolverTask?.value
 
     // Only the second resolver should have run (first was cancelled before calling resolver)
     #expect(callCount == 1)
@@ -188,10 +184,11 @@ struct CancelAllTests {
       return MediaResolvedUrl(url: src, headers: nil, userAgent: nil)
     }
     loader.resolveAndLoad(src: "https://example.com/audio.mp3")
+    // cancelAll() drops the handle, so grab it first to await the point where
+    // the callback would have fired.
+    let resolve = loader.mediaResolverTask
     loader.cancelAll()
-
-    // Wait for what would have been the callback
-    try? await Task.sleep(for: .milliseconds(100))
+    await resolve?.value
 
     #expect(spy.preparedItems.isEmpty)
     #expect(spy.playbackErrors.isEmpty)

--- a/ios/Tests/PlaybackCoordinatorTests.swift
+++ b/ios/Tests/PlaybackCoordinatorTests.swift
@@ -743,7 +743,7 @@ struct NaturalEndPlayIntentTests {
 @Suite("PlaybackCoordinator - healthy playback resets retry budget")
 struct HealthyPlaybackRetryResetTests {
   @Test @MainActor
-  func sustainedPlayback_resetsRetryBudget() async throws {
+  func sustainedPlayback_resetsRetryBudget() async {
     let retryHandler = MockRetryHandling()
     let errorHandler = PlaybackErrorHandler(retryHandler: retryHandler)
     let coordinator = PlaybackCoordinator(
@@ -754,7 +754,7 @@ struct HealthyPlaybackRetryResetTests {
     coordinator.healthyPlaybackDuration = 0.01
 
     coordinator.transition(.avPlayerPlaying)
-    try await Task.sleep(nanoseconds: 100_000_000)
+    await coordinator.healthyPlaybackTask?.value
 
     #expect(retryHandler.resetCallCount == 1)
   }
@@ -762,7 +762,7 @@ struct HealthyPlaybackRetryResetTests {
   /// resetRetry() cancels a pending retry — firing the refill mid-episode
   /// would kill an in-flight reconnect silently (stuck .playing forever).
   @Test @MainActor
-  func refill_skipsWhileRetryIsPending() async throws {
+  func refill_skipsWhileRetryIsPending() async {
     let retryHandler = MockRetryHandling()
     retryHandler.isRetryableResult = true
     retryHandler.attemptRetryDelayNs = 1_000_000_000
@@ -776,14 +776,14 @@ struct HealthyPlaybackRetryResetTests {
 
     coordinator.transition(.avPlayerPlaying)
     errorHandler.handleError(URLError(.timedOut), context: .playback)
-    try await Task.sleep(nanoseconds: 100_000_000)
+    await coordinator.healthyPlaybackTask?.value
 
     #expect(retryHandler.resetCallCount == 0)
     #expect(errorHandler.pendingRetryTask != nil)
   }
 
   @Test @MainActor
-  func playbackInterruptedBeforeThreshold_doesNotReset() async throws {
+  func playbackInterruptedBeforeThreshold_doesNotReset() async {
     let retryHandler = MockRetryHandling()
     let errorHandler = PlaybackErrorHandler(retryHandler: retryHandler)
     let coordinator = PlaybackCoordinator(
@@ -795,9 +795,12 @@ struct HealthyPlaybackRetryResetTests {
     coordinator.healthyPlaybackDuration = 0.5
 
     coordinator.transition(.avPlayerPlaying)
+    let refill = coordinator.healthyPlaybackTask
     coordinator.transition(.avPlayerWaiting) // stalls before the threshold
 
-    try await Task.sleep(nanoseconds: 100_000_000)
+    // Leaving .playing cancels the refill; awaiting the cancelled task is the
+    // deterministic way to reach the point where it would have fired.
+    await refill?.value
 
     #expect(retryHandler.resetCallCount == 0)
   }

--- a/ios/Tests/SleepTimerManagerTests.swift
+++ b/ios/Tests/SleepTimerManagerTests.swift
@@ -2,15 +2,15 @@
 import Foundation
 import Testing
 
-// Timing tests use generous margins (50ms+) around DispatchQueue scheduling
-// slop. While an @MainActor test awaits Task.sleep, the main queue is free to
-// run the manager's scheduled jobs.
+// Timing tests drive a ManualSleepTimerScheduler rather than the main queue:
+// every deadline below is virtual, so nothing races the real clock.
 
 @Suite("SleepTimerManager - fade scheduling")
 struct SleepTimerManagerTests {
   @Test @MainActor
-  func fadeFiresBeforeDeadline_completionDoesNotEmitFadeCancel() async throws {
-    let manager = SleepTimerManager()
+  func fadeFiresBeforeDeadline_completionDoesNotEmitFadeCancel() {
+    let clock = ManualSleepTimerScheduler()
+    let manager = SleepTimerManager(scheduler: clock)
     var fadeStarts: [TimeInterval] = []
     var completes = 0
     var cancels = 0
@@ -20,35 +20,37 @@ struct SleepTimerManagerTests {
     // Attach after set() — replacing a timer emits a defensive onFadeCancel.
     manager.onFadeCancel = { cancels += 1 }
 
-    try await Task.sleep(nanoseconds: 50_000_000) // 0.05s — before the fade window
+    clock.advance(to: 0.05) // before the fade window
     #expect(fadeStarts.isEmpty)
     #expect(manager.get() != nil)
 
-    try await Task.sleep(nanoseconds: 170_000_000) // ~0.22s — inside the fade window
+    clock.advance(to: 0.22) // inside the fade window
     #expect(fadeStarts == [0.15])
     #expect(completes == 0)
 
-    try await Task.sleep(nanoseconds: 180_000_000) // ~0.40s — past the deadline
+    clock.advance(to: 0.4) // past the deadline
     #expect(completes == 1)
     #expect(cancels == 0)
     #expect(manager.get() == nil)
   }
 
   @Test @MainActor
-  func fadeLongerThanTimer_clampsAndStartsImmediately() async throws {
-    let manager = SleepTimerManager()
+  func fadeLongerThanTimer_clampsAndStartsImmediately() {
+    let clock = ManualSleepTimerScheduler()
+    let manager = SleepTimerManager(scheduler: clock)
     var fadeStarts: [TimeInterval] = []
     manager.onFadeStart = { fadeStarts.append($0) }
 
     manager.set(seconds: 0.2, fadeDuration: 5)
 
-    try await Task.sleep(nanoseconds: 100_000_000) // 0.1s — fade should have begun
+    clock.advance(to: 0.1) // fade should have begun
     #expect(fadeStarts == [0.2])
   }
 
   @Test @MainActor
-  func clear_emitsFadeCancel_andCancelsScheduledFade() async throws {
-    let manager = SleepTimerManager()
+  func clear_emitsFadeCancel_andCancelsScheduledFade() {
+    let clock = ManualSleepTimerScheduler()
+    let manager = SleepTimerManager(scheduler: clock)
     var fadeStarts = 0
     manager.set(seconds: 0.2, fadeDuration: 0.15)
     var cancels = 0
@@ -58,13 +60,13 @@ struct SleepTimerManagerTests {
     #expect(manager.clear())
     #expect(cancels == 1)
 
-    try await Task.sleep(nanoseconds: 300_000_000) // well past the would-be deadline
+    clock.advance(to: 0.3) // well past the would-be deadline
     #expect(fadeStarts == 0)
   }
 
   @Test @MainActor
   func replacingTimer_emitsFadeCancel() {
-    let manager = SleepTimerManager()
+    let manager = SleepTimerManager(scheduler: ManualSleepTimerScheduler())
     manager.set(seconds: 60, fadeDuration: 10)
     var cancels = 0
     manager.onFadeCancel = { cancels += 1 }
@@ -76,7 +78,7 @@ struct SleepTimerManagerTests {
 
   @Test @MainActor
   func switchingToEndOfTrack_emitsFadeCancel() {
-    let manager = SleepTimerManager()
+    let manager = SleepTimerManager(scheduler: ManualSleepTimerScheduler())
     manager.set(seconds: 60, fadeDuration: 10)
     var cancels = 0
     manager.onFadeCancel = { cancels += 1 }
@@ -88,8 +90,9 @@ struct SleepTimerManagerTests {
   }
 
   @Test @MainActor
-  func noFadeDuration_schedulesNoFade() async throws {
-    let manager = SleepTimerManager()
+  func noFadeDuration_schedulesNoFade() {
+    let clock = ManualSleepTimerScheduler()
+    let manager = SleepTimerManager(scheduler: clock)
     var fadeStarts = 0
     var completes = 0
     manager.onFadeStart = { _ in fadeStarts += 1 }
@@ -97,7 +100,7 @@ struct SleepTimerManagerTests {
 
     manager.set(seconds: 0.1)
 
-    try await Task.sleep(nanoseconds: 200_000_000)
+    clock.advance(to: 0.2)
     #expect(fadeStarts == 0)
     #expect(completes == 1)
   }

--- a/ios/Tests/Support/ManualSleepTimerScheduler.swift
+++ b/ios/Tests/Support/ManualSleepTimerScheduler.swift
@@ -1,0 +1,47 @@
+@testable import AudioBrowserTestable
+import Foundation
+
+/// A job handed back by `ManualSleepTimerScheduler`.
+private final class ManualJob: SleepTimerJob {
+  nonisolated(unsafe) var isCancelled = false
+  func cancel() { isCancelled = true }
+}
+
+/// Deterministic stand-in for the main-queue scheduler: jobs fire only when the
+/// test advances the clock, so an assertion can never lose a race against a
+/// real deadline on a loaded CI runner.
+@MainActor
+final class ManualSleepTimerScheduler: SleepTimerScheduling {
+  private struct Entry {
+    let deadline: TimeInterval
+    let job: ManualJob
+    let work: @MainActor () -> Void
+  }
+
+  private var entries: [Entry] = []
+  private(set) var now: TimeInterval = 0
+
+  func schedule(
+    after delay: TimeInterval,
+    _ work: @escaping @Sendable @MainActor () -> Void,
+  ) -> any SleepTimerJob {
+    let job = ManualJob()
+    entries.append(Entry(deadline: now + delay, job: job, work: work))
+    return job
+  }
+
+  /// Moves the virtual clock to `time`, firing every due job in deadline order.
+  /// Jobs run one at a time so a job that schedules or cancels another (the
+  /// fade landing before completion) sees the same ordering it would in
+  /// production.
+  func advance(to time: TimeInterval) {
+    now = time
+    while let next = entries
+      .filter({ !$0.job.isCancelled && $0.deadline <= now })
+      .min(by: { $0.deadline < $1.deadline })
+    {
+      entries.removeAll { $0.job === next.job }
+      next.work()
+    }
+  }
+}


### PR DESCRIPTION
Fixes the three intermittent Swift test failures reported in #103.

## The defect

All three shared one shape: an assertion racing a real deadline. Each test used a wall-clock sleep as a proxy for "the async work has landed", so on a slow or oversubscribed runner the proxy expired at the wrong moment relative to the work — a call count still 0, an asset still nil, a fade completion firing when it should not have.

## The fix

Replace each proxy with the actual thing being waited on:

| test | change |
| --- | --- |
| `sustainedPlayback_resetsRetryBudget` | `PlaybackCoordinator.healthyPlaybackTask` is now readable, so the retry-budget tests `await` the refill window instead of sleeping 100ms past a 10ms one |
| `cancelsPreviousResolverTask` | `MediaLoader.mediaResolverTask` is now readable, so the resolver tests `await` the resolve-then-load chain instead of sleeping 200ms or counting `Task.yield()`s |
| `fadeFiresBeforeDeadline_completionDoesNotEmitFadeCancel` | `SleepTimerManager` takes an injected scheduler. Production keeps `DispatchQueue.main.asyncAfter`; tests drive a `ManualSleepTimerScheduler` they advance by hand, making the fade/deadline ordering virtual |

**No expectation was relaxed or removed.** Every `#expect` is unchanged — only the way each test reaches its assertion point. Per the note in #103, these needed real concurrency work rather than looser bounds.

Same-shaped siblings in the affected suites were converted too (`withResolver_callsResolver`, `withResolver_returningInvalidUrl_callsErrorDelegate`, `preventsDelegateCallbacksAfterResolveAndLoad`, and the rest of the sleep-timer suite) — they carried the identical latent race, and one of them did surface during stress runs.

## Verification

The flake was reproduced rather than assumed: the full suite run against a clean checkout under 384 competing CPU hogs, which emulates a loaded runner.

- **Before:** 11/15 runs failed — including all three reported failures at the same `file:line` with the same assertion text, plus a fourth (`SleepTimerManagerTests.swift:24`).
- **After:** 0/15 runs failed under identical load, 0/25 at a lighter load, and 508/508 pass unloaded.

On this branch, `swift test` passes 510/510.

The change is Swift-only, so the JS and Android gates are untouched, and `test.yml` has no Swift lint/format step.

Originally developed on `feature-fry` (where the gate in #101 surfaced this) and cherry-picked here with `-x`; all touched files were identical across the two branches, so it applied without conflicts.