### PR TITLE
fix(ci): build the example app's actual scheme name

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -105,7 +105,7 @@ jobs:
             CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
             -derivedDataPath build -UseModernBuildSystem=YES \
             -workspace AudioBrowserExample.xcworkspace \
-            -scheme AudioBrowserExample \
+            -scheme 'AudioBrowserExample (Debug)' \
             -sdk iphonesimulator \
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \


### PR DESCRIPTION
The iOS example build has been failing on every PR in this lineage:

```
xcodebuild: error: The workspace named "AudioBrowserExample" does not
contain a scheme named "AudioBrowserExample".
```

## Cause

c4dc7fc0 ("build(example): split iOS Debug/Release schemes and pin deployment target to 16.0") replaced the single `AudioBrowserExample` scheme with two:

```
apps/example-native/ios/AudioBrowserExample.xcodeproj/xcshareddata/xcschemes/
  AudioBrowserExample (Debug).xcscheme     → buildConfiguration = "Debug"
  AudioBrowserExample (Release).xcscheme   → buildConfiguration = "Release"
```

`ios-build.yml` was never updated to match, so it has been asking for a scheme that no longer exists. It's been failing since that rename — it is not a regression from any recent change, and the `Test` workflow (`swift test`, JS, Android) has been unaffected throughout.

## Fix

Point the build at the Debug scheme, which is consistent with the `-configuration Debug` the step already passes. One line; both matrix legs (new/old arch) share the step.

## Verification

I could not run `xcodebuild` locally (this machine has an unaccepted Xcode license), so this PR's own `Build iOS Example App (new)` / `(old)` runs are the verification — they exercise the exact command being changed. Worth confirming both go green before merging.