### PR TITLE
docs: emit clean URLs without the .html suffix

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -30,6 +30,11 @@ export default withMermaid(
 
     ignoreDeadLinks: true,
 
+    // Emit links without the .html suffix. Cloudflare Pages serves foo.html at
+    // /foo natively, and so does GitHub Pages, so this works on both hosts.
+    // Without it every internal link is a 308 redirect on Cloudflare.
+    cleanUrls: true,
+
     // Emitted here rather than committed to public/ so it only ever lands in a
     // DOCS_NOINDEX build — a noindex header file sitting in public/ would follow
     // a merge straight onto audiobrowser.dev.


### PR DESCRIPTION
VitePress was linking internally to `/guide/getting-started.html`. Cloudflare Pages 308-redirects that to the extensionless path, so every internal link cost a redirect — an extra round trip for anyone entering on a deep link, and a redirect on every internal link from a crawler's point of view.

`cleanUrls: true` makes VitePress emit `/guide/getting-started` while still writing `getting-started.html` to disk.

## Behaviour on both hosts

| Request | GitHub Pages | Cloudflare Pages |
| --- | --- | --- |
| `/guide/getting-started` | 200 | 200 |
| `/guide/getting-started.html` | 200 | 308 → extensionless |

Both serve `foo.html` at `/foo` natively, so this is correct on the current host and the future one. Already-indexed `.html` URLs keep resolving either way.

## Verification

- Built output links are extensionless: `href="/guide/getting-started"`
- Output files are unchanged on disk — still `guide/getting-started.html`
- `yarn ci:format` and `yarn ci:lint` pass