### PR TITLE
Merge main into next: clean URLs

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -30,6 +30,11 @@ export default withMermaid(
 
     ignoreDeadLinks: true,
 
+    // Emit links without the .html suffix. Cloudflare Pages serves foo.html at
+    // /foo natively, and so does GitHub Pages, so this works on both hosts.
+    // Without it every internal link is a 308 redirect on Cloudflare.
+    cleanUrls: true,
+
     // Emitted here rather than committed to public/ so it only ever lands in a
     // DOCS_NOINDEX build — a noindex header file sitting in public/ would follow
     // a merge straight onto audiobrowser.dev.


### PR DESCRIPTION
Brings `cleanUrls` from `main` (#111). VitePress now emits `/guide/foo` rather than `/guide/foo.html`; Cloudflare Pages 308-redirects the `.html` form, so without this every internal link costs a redirect.

## Conflict

One, and a false one — both branches added a different key at the same position in the config. Kept both: `srcExclude` from `next`, `cleanUrls` from `main`.

## Verification

- Build succeeds
- Internal links extensionless: `href="/guide/artwork"`
- `DOCS_NOINDEX=1` still emits `_headers` and the robots meta tag
- `srcExclude` still working — no `CLAUDE.html` in the output
- `yarn ci:format` and `yarn ci:lint` pass

Merging this triggers the first `next` preview build, which will publish the prerelease docs at `next.audiobrowser.pages.dev` with `X-Robots-Tag: noindex, nofollow`.