### PR TITLE
ci: gate releases on Test, never cancel one, pin the actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,61 @@ permissions:
   contents: read
 
 concurrency:
+  # Never cancel: semantic-release pushes the git tag before it publishes to
+  # npm, so a cancel in that window leaves a version tagged but unpublished,
+  # and a re-run then finds no new commits and reports "no new release".
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
+  # Release triggers on the same push as Test, so it would otherwise publish
+  # without waiting for the result — 0.2.0 shipped from a commit whose iOS job
+  # was red. Wait for Test on this exact SHA. No secrets and no environment
+  # here, so a hang cannot sit on the release credential.
+  gate:
+    name: Gate on Test
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Wait for Test to succeed on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "push" ]; then
+            echo "$GITHUB_EVENT_NAME run — skipping the Test gate"
+            exit 0
+          fi
+          deadline=$((SECONDS + 2700))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            run=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow Test \
+              --commit "$GITHUB_SHA" --limit 1 --json status,conclusion)
+            status=$(echo "$run" | jq -r '.[0].status // "missing"')
+            conclusion=$(echo "$run" | jq -r '.[0].conclusion // ""')
+            case "$status" in
+              completed)
+                if [ "$conclusion" = "success" ]; then
+                  echo "Test succeeded"
+                  exit 0
+                fi
+                echo "Test concluded '$conclusion' — refusing to release"
+                exit 1
+                ;;
+              missing) echo "waiting for Test to start…" ;;
+              *) echo "Test $status…" ;;
+            esac
+            sleep 20
+          done
+          echo "timed out waiting for Test"
+          exit 1
+
   release:
     name: Release
+    needs: gate
     runs-on: ubuntu-latest
-    # Holds the App key; only main and next can read it. No required
-    # reviewers — they would gate every release on a human.
+    # Holds the App key. Restricted to main and next — note next is push-open,
+    # so this narrows exposure rather than closing it. No required reviewers:
+    # they would gate every release on a human.
     environment: release
     permissions:
       # Nothing reads the automatic GITHUB_TOKEN. id-token is how npm publish
@@ -31,7 +77,7 @@ jobs:
       # actor on the main ruleset; github-actions[bot] cannot be one.
       - name: Mint a release token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -40,7 +86,7 @@ jobs:
       # token's push triggers workflows, so the only thing stopping a re-run
       # loop is the `[skip ci]` in @semantic-release/git's default message.
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
@@ -66,7 +112,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           cache: 'yarn'


### PR DESCRIPTION
Cherry-pick of the release-workflow half of the CI fixes already on `next`, where all of this is green (`0.2.0-next.9` published through it).

**Gate on Test.** Release triggers on the same push as Test and never waited for the result, so a red commit could publish — `0.2.0` shipped from a commit whose iOS job was failing. A `gate` job now polls for Test's conclusion on the same SHA. It carries no secrets and no environment, so a hang cannot sit on the release credential. `workflow_dispatch` skips the gate, since there is no matching Test run.

**`cancel-in-progress: false`.** semantic-release pushes the git tag before publishing to npm, so a cancel in that window leaves a version tagged but unpublished, and a re-run then finds no new commits and reports no new release. Queue instead of cancel.

**SHA-pin the three actions.** `create-github-app-token` receives the App private key directly, so a moved `v2` tag would be a key compromise.

Two consequences worth flagging:

- `main` cannot release while `PlaybackProgressUpdateManagerTests` "loading and buffering states also start timer" is flaking. That is the gate working, but landing the flaky-test fix is what unblocks it.
- With the nightly cron gone, a flaked release is not retried automatically. Recovery is to re-run Test, then re-run Release; the gate picks up the green result on the same SHA.

The other two CI commits on `next` (SwiftFormat pin fix, test job names) do not apply here — `main` has no SwiftFormat steps and its job names already match the ruleset. They arrive with the eventual merge.